### PR TITLE
Escape HTML in frontend views

### DIFF
--- a/public/admin/assets/attendance_entry.js
+++ b/public/admin/assets/attendance_entry.js
@@ -1,4 +1,5 @@
 import { fetchJSON, postJSON } from './helpers.js';
+import { escapeHtml } from '../../assets/utils.js';
 
 const jwt = localStorage.getItem('jwt');
 if (!jwt) { window.location.href = '/admin/index.php'; }
@@ -24,7 +25,7 @@ function fetchOptions() {
 
 function populateSelects() {
   selModalidad.innerHTML = '<option value="">--Seleccione--</option>' +
-    options.modalidades.map(m => `<option value="${m.id}">${m.nombre}</option>`).join('');
+    options.modalidades.map(m => `<option value="${m.id}">${escapeHtml(m.nombre)}</option>`).join('');
   selModalidad.addEventListener('change', handleModalidadChange);
   selGrado.addEventListener('change', handleGradoChange);
   handleModalidadChange();
@@ -35,7 +36,7 @@ function handleModalidadChange() {
   selGrado.innerHTML = '<option value="">--Seleccione--</option>';
   if (!modId) return;
   const grades = options.grados.filter(g => g.modalidad_id === modId);
-  selGrado.innerHTML += grades.map(g => `<option value="${g.id}">${g.nombre}</option>`).join('');
+  selGrado.innerHTML += grades.map(g => `<option value="${g.id}">${escapeHtml(g.nombre)}</option>`).join('');
   handleGradoChange();
 }
 
@@ -44,12 +45,12 @@ function handleGradoChange() {
   selSeccion.innerHTML = '<option value="">--Seleccione--</option>';
   if (!gradeId) return;
   const secs = options.secciones.filter(s => s.grado_id === gradeId);
-  selSeccion.innerHTML += secs.map(s => `<option value="${s.id}">${s.nombre}</option>`).join('');
+  selSeccion.innerHTML += secs.map(s => `<option value="${s.id}">${escapeHtml(s.nombre)}</option>`).join('');
 }
 
 function loadAsignaturas() {
   selAsignatura.innerHTML = '<option value="">--Seleccione--</option>' +
-    options.asignaturas.map(a => `<option value="${a.id}">${a.nombre}</option>`).join('');
+    options.asignaturas.map(a => `<option value="${a.id}">${escapeHtml(a.nombre)}</option>`).join('');
 }
 
 btnCargar.addEventListener('click', () => {
@@ -73,8 +74,8 @@ function renderList(list) {
   if (!list.length) { alert('Sin estudiantes'); return; }
   studentRows.innerHTML = list.map(l => `
     <tr>
-      <td class="border px-1 py-0.5 text-sm">${l.sigerd_id}</td>
-      <td class="border px-1 py-0.5 text-sm">${l.nombres} ${l.apellidos}</td>
+      <td class="border px-1 py-0.5 text-sm">${escapeHtml(l.sigerd_id)}</td>
+      <td class="border px-1 py-0.5 text-sm">${escapeHtml(l.nombres)} ${escapeHtml(l.apellidos)}</td>
       <td class="border px-1 py-0.5 text-sm">
         <input type="number" min="0" max="100" step="0.01" value="${l.porcentaje ?? ''}"
                class="w-24 border rounded p-1 text-center" />

--- a/public/admin/assets/grade_entry.js
+++ b/public/admin/assets/grade_entry.js
@@ -1,3 +1,5 @@
+import { escapeHtml } from '../../assets/utils.js';
+
 const jwt = localStorage.getItem('jwt');
 if (!jwt) {
   alert('Sesión expirada. Inicie sesión de nuevo.');
@@ -31,7 +33,7 @@ function fetchOptions() {
 function populateSelects() {
   // Modalidades
   selModalidad.innerHTML = '<option value="">--Seleccione--</option>' +
-    options.modalidades.map(m => `<option value="${m.id}">${m.nombre}</option>`).join('');
+    options.modalidades.map(m => `<option value="${m.id}">${escapeHtml(m.nombre)}</option>`).join('');
 
   // Events
   selModalidad.addEventListener('change', handleModalidadChange);
@@ -45,7 +47,7 @@ function handleModalidadChange() {
   if (!modId) return;
 
   const grades = options.grados.filter(g => g.modalidad_id === modId);
-  selGrado.innerHTML += grades.map(g => `<option value="${g.id}">${g.nombre}</option>`).join('');
+  selGrado.innerHTML += grades.map(g => `<option value="${g.id}">${escapeHtml(g.nombre)}</option>`).join('');
   handleGradoChange();
 }
 
@@ -55,13 +57,13 @@ function handleGradoChange() {
   if (!gradeId) return;
 
   const secs = options.secciones.filter(s => s.grado_id === gradeId);
-  selSeccion.innerHTML += secs.map(s => `<option value="${s.id}">${s.nombre}</option>`).join('');
+  selSeccion.innerHTML += secs.map(s => `<option value="${s.id}">${escapeHtml(s.nombre)}</option>`).join('');
 }
 
 // Asignaturas sin filtro adicional por ahora
 function loadAsignaturas() {
   selAsignatura.innerHTML = '<option value="">--Seleccione--</option>' +
-    options.asignaturas.map(a => `<option value="${a.id}">${a.nombre}</option>`).join('');
+    options.asignaturas.map(a => `<option value="${a.id}">${escapeHtml(a.nombre)}</option>`).join('');
 }
 
 btnCargar.addEventListener('click', () => {
@@ -102,8 +104,8 @@ function studentRowHtml(s) {
             class="w-20 border rounded p-1 text-center text-sm">`;
   return `
     <tr>
-      <td class="border px-1 py-0.5 text-sm">${s.sigerd_id}</td>
-      <td class="border px-1 py-0.5 text-sm">${s.nombres} ${s.apellidos}</td>
+      <td class="border px-1 py-0.5 text-sm">${escapeHtml(s.sigerd_id)}</td>
+      <td class="border px-1 py-0.5 text-sm">${escapeHtml(s.nombres)} ${escapeHtml(s.apellidos)}</td>
       <td class="border px-1 py-0.5">${makeInput('c1', s.c1)}</td>
       <td class="border px-1 py-0.5">${makeInput('rp1', s.rp1)}</td>
       <td class="border px-1 py-0.5">${makeInput('c2', s.c2)}</td>

--- a/public/admin/assets/students.js
+++ b/public/admin/assets/students.js
@@ -1,4 +1,5 @@
 import { fetchJSON, postJSON, putJSON, deleteReq } from './helpers.js';
+import { escapeHtml } from '../../assets/utils.js';
 
 const jwt = localStorage.getItem('jwt');
 if (!jwt) { window.location.href = '/admin/index.php'; }
@@ -15,11 +16,11 @@ function loadStudents() {
 function rowHtml(s) {
   return `
     <tr>
-      <td class="border px-1 py-0.5 text-sm">${s.sigerd_id}</td>
-      <td class="border px-1 py-0.5 text-sm">${s.nombres} ${s.apellidos}</td>
-      <td class="border px-1 py-0.5 text-sm">${s.modalidad}</td>
-      <td class="border px-1 py-0.5 text-sm">${s.grado}</td>
-      <td class="border px-1 py-0.5 text-sm">${s.seccion}</td>
+      <td class="border px-1 py-0.5 text-sm">${escapeHtml(s.sigerd_id)}</td>
+      <td class="border px-1 py-0.5 text-sm">${escapeHtml(s.nombres)} ${escapeHtml(s.apellidos)}</td>
+      <td class="border px-1 py-0.5 text-sm">${escapeHtml(s.modalidad)}</td>
+      <td class="border px-1 py-0.5 text-sm">${escapeHtml(s.grado)}</td>
+      <td class="border px-1 py-0.5 text-sm">${escapeHtml(s.seccion)}</td>
       <td class="border px-1 py-0.5 text-sm">
         <button class="text-blue-600" data-edit="${s.sigerd_id}">Editar</button>
         <button class="text-red-600 ml-2" data-del="${s.sigerd_id}">Eliminar</button>

--- a/public/admin/assets/teachers.js
+++ b/public/admin/assets/teachers.js
@@ -1,4 +1,5 @@
 import { fetchJSON, deleteReq } from './helpers.js';
+import { escapeHtml } from '../../assets/utils.js';
 
 const jwt = localStorage.getItem('jwt');
 if (!jwt) { window.location.href = '/admin/index.php'; }
@@ -15,11 +16,11 @@ function loadTeachers() {
 function rowHtml(t) {
   return `
     <tr>
-      <td class="border px-1 py-0.5 text-sm">${t.nombres} ${t.apellidos}</td>
-      <td class="border px-1 py-0.5 text-sm">${t.cedula}</td>
-      <td class="border px-1 py-0.5 text-sm">${t.telefono ?? ''}</td>
-      <td class="border px-1 py-0.5 text-sm">${t.asignatura}</td>
-      <td class="border px-1 py-0.5 text-sm">${t.grado ?? '-'}</td>
+      <td class="border px-1 py-0.5 text-sm">${escapeHtml(t.nombres)} ${escapeHtml(t.apellidos)}</td>
+      <td class="border px-1 py-0.5 text-sm">${escapeHtml(t.cedula)}</td>
+      <td class="border px-1 py-0.5 text-sm">${escapeHtml(t.telefono ?? '')}</td>
+      <td class="border px-1 py-0.5 text-sm">${escapeHtml(t.asignatura)}</td>
+      <td class="border px-1 py-0.5 text-sm">${escapeHtml(t.grado ?? '-')}</td>
       <td class="border px-1 py-0.5 text-sm">
         <button class="text-blue-600" data-edit="${t.id}">Editar</button>
         <button class="text-red-600 ml-2" data-del="${t.id}">Eliminar</button>

--- a/public/assets/utils.js
+++ b/public/assets/utils.js
@@ -1,0 +1,10 @@
+export function escapeHtml(str) {
+  if (str == null) return '';
+  return String(str).replace(/[&<>"']/g, c => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;'
+  }[c]));
+}

--- a/public/student/assets/bulletin.js
+++ b/public/student/assets/bulletin.js
@@ -1,4 +1,5 @@
 import { getStatusMessage } from './utils.js';
+import { escapeHtml } from '../../assets/utils.js';
 
 const container = document.getElementById('bulletinContainer');
 const jwt = localStorage.getItem('jwt');
@@ -17,7 +18,7 @@ if (!jwt) {
     })
     .catch(err => {
       container.innerHTML =
-        `<p class="text-center text-red-500">${err.message}</p>`;
+        `<p class="text-center text-red-500">${escapeHtml(err.message)}</p>`;
     });
 }
 
@@ -27,15 +28,15 @@ function renderBulletin(info) {
   /* ---------- Encabezado ---------- */
   const header = /*html*/ `
     <header class="text-center mb-6">
-      <h1 class="text-2xl font-bold">${center.name}</h1>
-      <p class="text-sm">Código: ${center.code}</p>
-      <p class="text-sm mb-4">${center.address}</p>
+      <h1 class="text-2xl font-bold">${escapeHtml(center.name)}</h1>
+      <p class="text-sm">Código: ${escapeHtml(center.code)}</p>
+      <p class="text-sm mb-4">${escapeHtml(center.address)}</p>
 
       <h2 class="text-xl font-semibold mt-4">Boletín de Calificaciones</h2>
-      <p class="mt-2"><strong>Estudiante:</strong> ${student.nombres} ${student.apellidos}</p>
-      <p><strong>ID SIGERD:</strong> ${student.sigerd_id}</p>
-      <p><strong>Modalidad:</strong> ${student.modalidad}</p>
-      <p><strong>Grado y Sección:</strong> ${student.grado} — ${student.seccion}</p>
+      <p class="mt-2"><strong>Estudiante:</strong> ${escapeHtml(student.nombres)} ${escapeHtml(student.apellidos)}</p>
+      <p><strong>ID SIGERD:</strong> ${escapeHtml(student.sigerd_id)}</p>
+      <p><strong>Modalidad:</strong> ${escapeHtml(student.modalidad)}</p>
+      <p><strong>Grado y Sección:</strong> ${escapeHtml(student.grado)} — ${escapeHtml(student.seccion)}</p>
     </header>
   `;
 
@@ -52,7 +53,7 @@ function renderBulletin(info) {
 
     return `
       <tr>
-        <td class="border px-2 py-1">${s.asignatura}</td>
+        <td class="border px-2 py-1">${escapeHtml(s.asignatura)}</td>
         ${periodCells}
         <td class="border px-2 py-1 text-center font-semibold ${finalClass}">
           ${s.final}
@@ -86,12 +87,12 @@ function renderBulletin(info) {
     <div class="flex justify-around mt-8 text-center">
       <div>
         ___________________________<br>
-        ${signatories.director}<br>
+        ${escapeHtml(signatories.director)}<br>
         <span class="font-semibold">Directora</span>
       </div>
       <div>
         ___________________________<br>
-        ${signatories.registrar}<br>
+        ${escapeHtml(signatories.registrar)}<br>
         <span class="font-semibold">Registro & Control Académico</span>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add a reusable `escapeHtml` helper
- escape bulletin values before injecting them
- sanitize student list output
- sanitize teacher list output
- escape values in attendance and grade entry modules

## Testing
- `composer validate --no-check-publish` *(fails: composer not installed)*
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6842e6ffe35483238a5857455339aebd