### PR TITLE
Fix grade default and use env DB settings

### DIFF
--- a/src/config/db.php
+++ b/src/config/db.php
@@ -4,6 +4,7 @@ namespace App\Config;
 
 use PDO;
 use PDOException;
+use App\Config\Env;
 
 class Database
 {
@@ -12,10 +13,10 @@ class Database
     public static function getConnection(): PDO
     {
         if (self::$instance === null) {
-            $host = 'localhost';
-            $db   = 'boletines';
-            $user = 'root';
-            $pass = '';
+            $host = Env::get('DB_HOST', 'localhost');
+            $db   = Env::get('DB_NAME', 'boletines');
+            $user = Env::get('DB_USER', 'root');
+            $pass = Env::get('DB_PASS', '');
             $charset = 'utf8mb4';
 
             $dsn = "mysql:host=$host;dbname=$db;charset=$charset";

--- a/src/services/GradeService.php
+++ b/src/services/GradeService.php
@@ -82,7 +82,7 @@ class GradeService
         foreach ($grades as $g) {
             $sid    = $g['sigerd_id'];
             $notes  = $g['competencies'];
-            $rps    = $g['rp'] ?? [None, None, None, None];
+            $rps    = $g['rp'] ?? [null, null, null, null];
 
             for ($i = 0; $i < 4; $i++) {
                 $stmt->execute([


### PR DESCRIPTION
## Summary
- use environment variables for database connection
- fix undefined `None` constant when saving grade remediation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842ea605a90832389cd0bfdea9bfff4