### PR TITLE
Fix captcha failure handling

### DIFF
--- a/src/services/CaptchaService.php
+++ b/src/services/CaptchaService.php
@@ -12,19 +12,35 @@ class CaptchaService
         $secret = Env::get('CAPTCHA_SECRET');
         if (!$secret) return false;
 
-        $response = file_get_contents('https://www.google.com/recaptcha/api/siteverify', false,
+        $response = file_get_contents(
+            'https://www.google.com/recaptcha/api/siteverify',
+            false,
             stream_context_create([
                 'http' => [
                     'method'  => 'POST',
                     'header'  => 'Content-type: application/x-www-form-urlencoded',
                     'content' => http_build_query([
                         'secret'   => $secret,
-                        'response' => $token
+                        'response' => $token,
                     ])
                 ]
             ])
         );
+
+        if ($response === false) {
+            return false;
+        }
+
         $data = json_decode($response, true);
-        return $data['success'] && $data['action'] === $action && $data['score'] >= 0.5;
+
+        if (!is_array($data)) {
+            return false;
+        }
+
+        $success = $data['success'] ?? false;
+        $score   = $data['score'] ?? 0;
+        $act     = $data['action'] ?? '';
+
+        return $success && $act === $action && $score >= 0.5;
     }
 }


### PR DESCRIPTION
## Summary
- improve captcha verification by checking for network failures and missing fields

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ebc3d81c8323879842d199149fa6