### PR TITLE
Fix recaptcha paths in admin login page

### DIFF
--- a/public/admin/index.php
+++ b/public/admin/index.php
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Admin • Boletines</title>
   <script src="https://cdn.tailwindcss.com"></script>
-  <script type="module" src="assets/recaptcha.js"></script>
+  <script type="module" src="/assets/recaptcha.js"></script>
 </head>
 <body class="min-h-screen flex items-center justify-center bg-gray-50">
   <div class="w-full max-w-sm bg-white shadow-lg rounded-2xl p-6">
@@ -36,7 +36,7 @@
   </div>
 
   <script type="module">
-    import { getToken } from './assets/recaptcha.js';
+    import { getToken } from '/assets/recaptcha.js';
     const siteKey = '<?php echo htmlspecialchars(App\Config\Env::get("CAPTCHA_SITEKEY")); ?>';
 
     document.getElementById('adminLoginForm').addEventListener('submit', async (e) => {


### PR DESCRIPTION
## Summary
- fix asset path for recaptcha module script in `public/admin/index.php`
- update inline module import path

## Testing
- `php -l public/admin/index.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842ee290dc48323931bf163c7277aed