### PR TITLE
Add rollback on exceptions

### DIFF
--- a/src/services/AttendanceService.php
+++ b/src/services/AttendanceService.php
@@ -39,23 +39,29 @@ class AttendanceService
     {
         $db = Database::getConnection();
         $db->beginTransaction();
-        $sql = '
-            INSERT INTO asistencias
-                (estudiante_id, asignatura_id, periodo, porcentaje)
-            VALUES
-                (:sid, :subject, :period, :percent)
-            ON DUPLICATE KEY UPDATE
-                porcentaje = VALUES(porcentaje)';
-        $stmt = $db->prepare($sql);
 
-        foreach ($records as $r) {
-            $stmt->execute([
-                ':sid'     => $r['sigerd_id'],
-                ':subject' => $subjectId,
-                ':period'  => $period,
-                ':percent' => $r['porcentaje'],
-            ]);
+        try {
+            $sql = '
+                INSERT INTO asistencias
+                    (estudiante_id, asignatura_id, periodo, porcentaje)
+                VALUES
+                    (:sid, :subject, :period, :percent)
+                ON DUPLICATE KEY UPDATE
+                    porcentaje = VALUES(porcentaje)';
+            $stmt = $db->prepare($sql);
+
+            foreach ($records as $r) {
+                $stmt->execute([
+                    ':sid'     => $r['sigerd_id'],
+                    ':subject' => $subjectId,
+                    ':period'  => $period,
+                    ':percent' => $r['porcentaje'],
+                ]);
+            }
+            $db->commit();
+        } catch (\Throwable $th) {
+            $db->rollBack();
+            throw $th;
         }
-        $db->commit();
     }
 }


### PR DESCRIPTION
## Summary
- wrap GradeService transaction in try/catch
- wrap AttendanceService transaction in try/catch

## Testing
- `composer validate --no-check-publish` *(fails: command not found)*
- `php -l src/services/GradeService.php` *(fails: command not found)*
- `php -l src/services/AttendanceService.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ee2e06508323b9ce2b1f67f71933